### PR TITLE
Add HPND to list of default allowed licenses

### DIFF
--- a/allowed-licenses.txt
+++ b/allowed-licenses.txt
@@ -13,3 +13,4 @@ MIT License
 Mozilla Public License 2.0 (MPL 2.0)
 Python Software Foundation License
 Zope Public License
+Historical Permission Notice and Disclaimer (HPND)


### PR DESCRIPTION
This is the license of Pillow: https://github.com/python-pillow/Pillow

Seems like an old license that is deprecated now, but not copyleft: https://en.wikipedia.org/wiki/Historical_Permission_Notice_and_Disclaimer