### PR TITLE
Chore: Add missing SPDX Identifiers for allowed licenses

### DIFF
--- a/allowed-licenses.txt
+++ b/allowed-licenses.txt
@@ -9,10 +9,15 @@ BSD License
 BSD 3-Clause
 BSD-3-Clause
 ISC License (ISCL)
+ISC
 MIT
 MIT License
 CMU License (MIT-CMU)
+MIT-CMU
 Mozilla Public License 2.0 (MPL 2.0)
+MPL-2.0
 Python Software Foundation License
+PSF-2.0
 Zope Public License
 Historical Permission Notice and Disclaimer (HPND)
+HPND


### PR DESCRIPTION
Since some python packages are now moving to using [PEP 639](https://peps.python.org/pep-0639/) for specifying licenses, some of the allowed licenses stopped being recognized correctly.

This PR adds the missing [SPDX Identifiers](https://spdx.org/licenses/) that were missing for some of the licenses (written right under the license they are representing).