### PR TITLE
Add BSD-2-Clause to allowlist

### DIFF
--- a/allowed-licenses.txt
+++ b/allowed-licenses.txt
@@ -8,6 +8,7 @@ BSD
 BSD License
 BSD 3-Clause
 BSD-3-Clause
+BSD-2-Clause
 ISC License (ISCL)
 ISC
 MIT


### PR DESCRIPTION
Adds [BSD-2-Clause](https://opensource.org/license/bsd-2-clause), which is a more permissive version of an already allowed [BSD-3-Clause](https://opensource.org/license/bsd-3-clause)

Will allow using modern versions of [Pygments](https://github.com/pygments/pygments), which is currently failing in client tests: https://github.com/DagsHub/client/actions/runs/24346222624/job/71087718596?pr=678