### PR TITLE
Fix: allow numpy license

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.11
+FROM python:3.14
 
-RUN pip install pip-licenses-cli==1.0.0 pipdeptree
+RUN pip install pip-licenses-cli[spdx]==4.0.0 pipdeptree
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY allowed-licenses.txt /allowed-licenses.txt

--- a/allowed-licenses.txt
+++ b/allowed-licenses.txt
@@ -22,3 +22,4 @@ PSF-2.0
 Zope Public License
 Historical Permission Notice and Disclaimer (HPND)
 HPND
+BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0


### PR DESCRIPTION
This PR:
- Bumps docker container python version to 3.14
- Bumps `python-license-cli` version to current upstream 4.0.0
- Installs optional dependency for `python-license-cli` to allow parsing of SPDX licenses
- Adds the numpy license expression of `BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0` to the list of allowed licenses (since the license validator can't handle AND clauses, we're approving it manually)

Tested the docker container on the current `main` of the client, and the license validation now passes